### PR TITLE
[GT-28] Transformation algorithm 적용한 prototype

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbobject/Table.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbobject/Table.java
@@ -53,6 +53,9 @@ public class Table extends
 	private String createSql;
 	private boolean isReuseOID = false;
 
+	private int importedKeysCount;
+	private int exportedKeysCount;
+
 	public boolean isReuseOID() {
 		return isReuseOID;
 	}
@@ -309,5 +312,41 @@ public class Table extends
 	 */
 	public boolean hasPK() {
 		return pk != null && CollectionUtils.isNotEmpty(pk.getPkColumns());
+	}
+
+	/**
+	 * getImportedKeysCount
+	 *
+	 * @return the importedKeysCount
+	 */
+	public int getImportedKeysCount() {
+		return importedKeysCount;
+	}
+
+	/**
+	 * setImportedKeysCount
+	 *
+	 * @param importedKeysCount
+	 */
+	public void setImportedKeysCount(int importedKeysCount) {
+		this.importedKeysCount = importedKeysCount;
+	}
+
+	/**
+	 * getExportedKeysCount
+	 *
+	 * @return the exportedKeysCount
+	 */
+	public int getExportedKeysCount() {
+		return exportedKeysCount;
+	}
+
+	/**
+	 * setExportedKeysCount
+	 *
+	 * @param exportedKeysCount
+	 */
+	public void setExportedKeysCount(int exportedKeysCount) {
+		this.exportedKeysCount = exportedKeysCount;
 	}
 }

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
@@ -1036,6 +1036,63 @@ public final class CUBRIDSchemaFetcher extends
 		buildCUBRIDTablePKs(conn, tables);
 		buildCUBRIDTableFKs(conn, tables, schema, catalog);
 		buildCUBRIDTableIndexes(conn, tables);
+
+		for (Table table : tables.values()) {
+			setImportedKeysCount(conn, catalog, schema, table);
+			setExportedKeysCount(conn, catalog, schema, table);
+		}
+	}
+
+	/**
+	 * setImportedKeysCount
+	 *
+	 * @param conn
+	 * @param catalog
+	 * @param schema
+	 * @param table
+	 * @throws SQLException
+	 */
+	protected void setImportedKeysCount(final Connection conn, final Catalog catalog, final Schema schema,
+			Table table) throws SQLException {
+
+		int importedKeysCount = 0;
+
+		ResultSet rs = null;
+		try {
+			rs = conn.getMetaData().getImportedKeys(getCatalogName(catalog), getSchemaName(schema), table.getName());
+			while (rs.next()) {
+				importedKeysCount++;
+			}
+			table.setImportedKeysCount(importedKeysCount);
+		} finally {
+			Closer.close(rs);
+		}
+	}
+
+	/**
+	 * setExportedKeysCount
+	 *
+	 * @param conn
+	 * @param catalog
+	 * @param schema
+	 * @param table
+	 * @throws SQLException
+	 */
+	protected void setExportedKeysCount(final Connection conn, final Catalog catalog, final Schema schema,
+			Table table) throws SQLException {
+
+		int exportedKeysCount = 0;
+
+		ResultSet rs = null;
+		try {
+			rs = conn.getMetaData().getExportedKeys(getCatalogName(catalog), getSchemaName(schema), table.getName());
+			while (rs.next()) {
+				exportedKeysCount++;
+			}
+			table.setExportedKeysCount(exportedKeysCount);
+		} finally {
+			Closer.close(rs);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Description
--
Relational DB to Graph DB 이관 전 데이터 변환 작업을 하기 위해  [A comprehensive approach for converting relational to graph database using spark 논문](http://www.jatit.org/volumes/Vol99No12/16Vol99No12.pdf) 내 [3.1.2] transformation algorithm의 내용을 적용한 prototype 코드입니다.

CUBRID의 테이블을 아래의 타입으로 구분하는 기능입니다.
- JoinTables Edges
- Intermediate Nodes
- First Nodes
- Seconds Nodes
- Recursive Edges

Additional Information
--
ObjectMappingPage의 printTableElement 메소드는 변환될 테이블의 종류을 확인하기 위해 만들어진 메소드이므로 삭제하셔도 됩니다.