### PR TITLE
[GT-83] join table edge를 이관할 때 FK column과 참조 column이 다르면 오류 발생

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/GraphJDBCImporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/GraphJDBCImporter.java
@@ -239,17 +239,17 @@ public class GraphJDBCImporter extends
 	}
 	
 	private String getTargetInsertJoinEdge(Edge e) {
-		
-		if (!e.getColumnbyName(e.getFKColumnNames().get(0)).getSupportGraphDataType()
-				|| !e.getColumnbyName(e.getREFColumnNames(e.getFKColumnNames().get(0))).getSupportGraphDataType()) {
-			return null;
-		}
-		
 		StringBuffer buffer = new StringBuffer();
 		buffer.append("Match (n:").append(e.getStartVertexName());
 		buffer.append("), (m:").append(e.getEndVertexName());
 		buffer.append(")");
-		buffer.append(" where n.").append(e.getFKColumnNames().get(0)).append(" = ");
+		
+		if (e.getStartVertexName().equals(e.getEndVertexName())) {
+			buffer.append(" where n.").append(e.getREFColumnNames(e.getFKColumnNames().get(1))).append(" = ");
+		} else {
+			buffer.append(" where n.").append(e.getFKColumnNames().get(0)).append(" = ");
+		}
+		
 		buffer.append("?");
 		buffer.append(" and m.").append(e.getREFColumnNames(e.getFKColumnNames().get(1))).append(" = ");
 		buffer.append("?");


### PR DESCRIPTION
http://jira.iitp.cubrid.org/browse/GT-83

- 각 컬럼명이 서로 다른 경우 참조하는 컬럼 명을 적용하도록 수정