### PR TITLE
[GT-141] 문자열 타입 출력 시 trim 처리 기능 추가

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
@@ -1099,7 +1099,7 @@ public abstract class OfflineImporter extends
 				continue;
 			}
 			
-			recordList.add(colVal.getValue().toString());
+			recordList.add(colVal.getValue().toString().trim());
 		}
 		
 		return recordList;


### PR DESCRIPTION
- 쿼리 수행 시 공백으로 인한 문제 방지를 위해 문자열 타입을 출력할 때 record를 trim하여 출력한다